### PR TITLE
[#11] [#13] Data Exploration: extract word analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv
 .vscode
 __pycache__/
+.idea/

--- a/cleaner.py
+++ b/cleaner.py
@@ -1,6 +1,6 @@
 import nltk
 from nltk.corpus import stopwords
-from nltk.stem import PorterStemmer, WordNetLemmatizer
+from nltk.stem import WordNetLemmatizer
 from nltk.tag import pos_tag
 from nltk.tokenize import sent_tokenize, word_tokenize
 from pyspark.sql import Row
@@ -12,7 +12,8 @@ nltk.download('stopwords')
 nltk.download('wordnet')
 nltk.download('averaged_perceptron_tagger')
 STOPWORDS_SET = set(stopwords.words('english'))
-  
+
+
 def main():
     spark = init_spark()
     rdd = spark.read.format('mongo').load().rdd
@@ -22,6 +23,7 @@ def main():
 
 def clean_data(rdd):
     lemmatizer = WordNetLemmatizer()
+
     def filter_word(word, pos):
         """Filters out stop words, punctuation, numbers, and proper nouns
         Arguments:
@@ -33,7 +35,7 @@ def clean_data(rdd):
         """
         is_stopword = word in STOPWORDS_SET
         is_word = word.isalnum()
-        is_number = word.replace('.','',1).isdigit()
+        is_number = word.replace('.', '', 1).isdigit()
         # str.isdigit returns false with numbers that have a decimal point
         # so replacing it with a number makes it work as intended
         is_proper_noun = pos == 'NNP'
@@ -59,6 +61,7 @@ def clean_data(rdd):
         return Row(content=content, header=header, label=record['label'], created_at=record['created_at'])
 
     return rdd.map(process_record)
+
 
 if __name__ == '__main__':
     main()

--- a/config.py
+++ b/config.py
@@ -1,0 +1,5 @@
+AITA_DB_NAME = 'aitaDB'
+AITA_EXTRACTED_COLLECTION = 'extractedinfo'
+AITA_CLEANED_COLLECTION = 'cleaneddata'
+
+MONGO_CONNECTION_STRING = 'mongodb://127.0.0.1'

--- a/constants.py
+++ b/constants.py
@@ -1,0 +1,11 @@
+NTAH = 'NOT THE A-HOLE'
+AH = 'ASSHOLE'
+NAH = 'NO A-HOLES HERE'
+ES = 'EVERYONE SUCKS'
+
+label_colors = {
+    NTAH: 'green',
+    AH: 'red',
+    NAH: 'grey',
+    ES: 'black'
+}

--- a/data_exploration/class_distribution.py
+++ b/data_exploration/class_distribution.py
@@ -4,9 +4,11 @@ import numpy as np
 import sys
 sys.path.append('../')
 from spark.init_spark import init_spark
+from config import AITA_EXTRACTED_COLLECTION
+
 
 def class_distribution():
-    spark = init_spark()
+    spark = init_spark(AITA_EXTRACTED_COLLECTION)
     df = spark.read.format('mongo').load()
     
     distribution = df.groupBy('label').count().collect()
@@ -18,7 +20,7 @@ def show_bar_plot(distribution):
     labels = [row['label'] for row in distribution]
 
     y_pos = np.arange(len(labels))
-    plt.figure(figsize=(10,5))
+    plt.figure(figsize=(10, 5))
     plt.bar(y_pos, counts, color=['grey', 'black', 'red', 'green'])
     plt.xticks(y_pos, labels)
 

--- a/data_exploration/time_analysis.py
+++ b/data_exploration/time_analysis.py
@@ -6,13 +6,14 @@ import numpy as np
 import sys
 sys.path.append('../')
 from spark.init_spark import init_spark
+from config import AITA_EXTRACTED_COLLECTION
+
 
 def days_of_the_week_count():
-    spark = init_spark()
+    spark = init_spark(AITA_EXTRACTED_COLLECTION)
     posts = spark.read.format('mongo').load().rdd
 
     def get_weekday(timestamp):
-        days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
         return datetime.datetime.fromtimestamp(timestamp).weekday()
 
     label_day = posts \

--- a/data_exploration/time_analysis.py
+++ b/data_exploration/time_analysis.py
@@ -7,7 +7,7 @@ import sys
 sys.path.append('../')
 from spark.init_spark import init_spark
 from config import AITA_EXTRACTED_COLLECTION
-
+from constants import NAH, AH, NTAH, ES, label_colors
 
 def days_of_the_week_count():
     spark = init_spark(AITA_EXTRACTED_COLLECTION)
@@ -24,18 +24,16 @@ def days_of_the_week_count():
 
     label_day = sorted(label_day, key=lambda t: t[0][1])
 
-    labels = ['NO A-HOLES HERE', 'ASSHOLE', 'NOT THE A-HOLE', 'EVERYONE SUCKS']
-
     d = collections.defaultdict(list)
 
     for val in label_day:
         label = val[0][0]
         d[label].append(val[1])
 
-    nah = d[labels[0]]
-    ah = d[labels[1]]
-    ntah = d[labels[2]]
-    es = d[labels[3]]
+    nah = d[NAH]
+    ah = d[AH]
+    ntah = d[NTAH]
+    es = d[ES]
 
     bottom_ntah = np.add(nah, ah).tolist()
     bottom_es = np.add(bottom_ntah, ntah).tolist()
@@ -44,17 +42,17 @@ def days_of_the_week_count():
 
     plt.figure(figsize=(10,5))
 
-    p1 = plt.bar(r, nah, color='grey')
-    p2 = plt.bar(r, ah, bottom=nah, color='red')
-    p3 = plt.bar(r, ntah, bottom=bottom_ntah, color='green')
-    p4 = plt.bar(r, es, bottom=bottom_es, color='black')
+    p1 = plt.bar(r, nah, color=label_colors.get(NAH))
+    p2 = plt.bar(r, ah, bottom=nah, color=label_colors.get(AH))
+    p3 = plt.bar(r, ntah, bottom=bottom_ntah, color=label_colors.get(NTAH))
+    p4 = plt.bar(r, es, bottom=bottom_es, color=label_colors.get(ES))
 
     plt.title('Distribution of days when posts were submitted to r/AITA, per label')
     plt.xticks(r, ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'])
     plt.xlabel('Day of the week')
     plt.ylabel('Number of posts')
 
-    plt.legend((p1[0], p2[0], p3[0], p4[0]), labels)
+    plt.legend((p1[0], p2[0], p3[0], p4[0]), [NAH, AH, NTAH, ES])
 
     plt.show()
 

--- a/data_exploration/word_frequency.py
+++ b/data_exploration/word_frequency.py
@@ -15,6 +15,14 @@ words_to_ignore = ['i', 'u', 'aita', 'like', 'would', 'this', 'it', 'get', 'got'
 
 
 def word_frequency(n):
+    """Generates four plots for each AITA label that display the distribution of their top n words.
+
+    Arguments:
+         n {integer} -- Number of top words to display
+
+    Returns:
+        None
+    """
     spark = init_spark(AITA_CLEANED_COLLECTION)
     data_rdd = spark.read.format('mongo').load().rdd
 

--- a/data_exploration/word_frequency.py
+++ b/data_exploration/word_frequency.py
@@ -7,10 +7,8 @@ from spark.init_spark import init_spark
 from config import AITA_CLEANED_COLLECTION
 
 
-adjective_tags = ['JJ', 'JJR', 'JJS']
-words_to_ignore = ['i', 'u', 'aita', 'like', 'would', 'this', 'it', 'get', 'got', 'the']
-
 N = 30
+words_to_ignore = ['i', 'u', 'aita', 'like', 'would', 'this', 'it', 'get', 'got', 'the']
 
 
 def word_frequency(n):

--- a/data_exploration/word_frequency.py
+++ b/data_exploration/word_frequency.py
@@ -1,31 +1,16 @@
 import matplotlib.pyplot as plt
 import numpy as np
-from pyspark.sql import Row
-import collections
-
-import nltk
-from nltk import pos_tag
 
 import sys
 sys.path.append('../')
 from spark.init_spark import init_spark
 from config import AITA_CLEANED_COLLECTION
 
-nltk.download('averaged_perceptron_tagger')
 
 adjective_tags = ['JJ', 'JJR', 'JJS']
 words_to_ignore = ['i', 'u', 'aita', 'like', 'would', 'this', 'it', 'get', 'got', 'the']
 
-
-labels = ['NO A-HOLES HERE', 'ASSHOLE', 'NOT THE A-HOLE', 'EVERYONE SUCKS']
-
-
-def fill_0_values(max_label_len, list):
-    list_len = len(list)
-    if list_len < max_label_len:
-        list.extend([0] * (max_label_len - list_len))
-
-    return list
+N = 30
 
 
 def word_frequency(n):
@@ -44,127 +29,32 @@ def word_frequency(n):
         return words
 
     flattened_rdd = data_rdd \
-        .flatMap(lambda row: [Row(label=row['label'], word=word) for word in filter(row)])
+        .flatMap(lambda row: filter(row))
 
     result_rdd = flattened_rdd \
-        .map(lambda row: ((row['label'], row['word']), 1)) \
+        .map(lambda x: (x, 1)) \
         .reduceByKey(lambda x, y: x+y) \
         .sortBy(lambda x: -x[1])
 
     result = result_rdd.take(n)
-    print(result)
-    labels = spark.sparkContext.parallelize(result).map(lambda x: x[0][1]).distinct().collect()
+    plot_count(result, n)
 
-    r_data = labels
-    x = range(len(r_data))
 
-    d = collections.defaultdict(list)
+def plot_count(data, n):
+    words = [row[0] for row in data]
+    counts = [row[1] for row in data]
 
-    for val in result:
-        print(val)
-        label = val[0][0]
-        d[label].append(val[1])
-
-    print(d[labels[0]])
-    print(d[labels[1]])
-    print(d[labels[2]])
-    print(d[labels[3]])
-
-    max_label_len = len(d[[k for k in d.keys() if len(d.get(k)) == max([len(n) for n in d.values()])][0]])
-
-    nah = fill_0_values(max_label_len, d[labels[0]])
-    ah = fill_0_values(max_label_len, d[labels[1]])
-    ntah = fill_0_values(max_label_len, d[labels[2]])
-    es = fill_0_values(max_label_len, d[labels[3]])
-    print(nah)
-    print(ah)
-    print(ntah)
-    print(es)
-
-    bottom_ntah = np.add(nah, ah).tolist()
-    bottom_es = np.add(bottom_ntah, ntah).tolist()
-
+    y_pos = np.arange(len(words))
     plt.figure(figsize=(20, 5))
+    plt.bar(y_pos, counts)
+    plt.xticks(y_pos, words)
 
-    p1 = plt.bar(x, nah, color='grey')
-    p2 = plt.bar(x, ah, bottom=nah, color='red')
-    p3 = plt.bar(x, ntah, bottom=bottom_ntah, color='green')
-    p4 = plt.bar(x, es, bottom=bottom_es, color='black')
-
-    plt.title('Distribution of the top {} {} for posts in r/AITA'.format(n, 'words'))
-    plt.xticks(x, r_data)
-    plt.xlabel('Words')
+    plt.title('Distribution of the top {} words for posts in r/AITA'.format(n))
     plt.ylabel('Count')
-
-    plt.legend((p1[0], p2[0], p3[0], p4[0]), labels)
-
-    plt.show()
-
-
-def adjective_frequency(n):
-    spark = init_spark(AITA_CLEANED_COLLECTION)
-    data_rdd = spark.read.format('mongo').load().rdd
-
-    def filter(row):
-        words = []
-        list = pos_tag([word.lower() for sublist in row['header'] for word in sublist] + \
-                         [word.lower() for sublist in row['content'] for word in sublist])
-        for word in list:
-            if word[1] in adjective_tags and word[0] not in words_to_ignore:
-                words.append(word[0])
-
-        return words
-
-    flattened_rdd = data_rdd.flatMap(lambda row: [Row(label=row['label'], word=word) for word in filter(row)])
-
-    result_rdd = flattened_rdd\
-        .map(lambda row: ((row['label'], row['word']), 1)) \
-        .reduceByKey(lambda x, y: x+y) \
-        .sortBy(lambda x: -x[1])
-
-    result = result_rdd.take(n)
-    labels = spark.sparkContext.parallelize(result).map(lambda x: x[0][1]).distinct().collect()
-
-    plot_count_by_label('adjectives', result, labels, n)
-
-
-def plot_count_by_label(pos, data, labels, n):
-    r_data = labels
-    x = range(len(r_data))
-
-    d = collections.defaultdict(list)
-
-    for val in data:
-        label = val[0][0]
-        d[label].append(val[1])
-
-    max_label_len = len(d[[k for k in d.keys() if len(d.get(k)) == max([len(n) for n in d.values()])][0]])
-
-    nah = fill_0_values(max_label_len, d[labels[0]])
-    ah = fill_0_values(max_label_len, d[labels[1]])
-    ntah = fill_0_values(max_label_len, d[labels[2]])
-    es = fill_0_values(max_label_len, d[labels[3]])
-
-    bottom_ntah = np.add(nah, ah).tolist()
-    bottom_es = np.add(bottom_ntah, ntah).tolist()
-
-    plt.figure(figsize=(20, 5))
-
-    p1 = plt.bar(x, nah, color='grey')
-    p2 = plt.bar(x, ah, bottom=nah, color='red')
-    p3 = plt.bar(x, ntah, bottom=bottom_ntah, color='green')
-    p4 = plt.bar(x, es, bottom=bottom_es, color='black')
-
-    plt.title('Distribution of the top {} {} for posts in r/AITA'.format(n, pos))
-    plt.xticks(x, r_data)
     plt.xlabel('Words')
-    plt.ylabel('Count')
-
-    plt.legend((p1[0], p2[0], p3[0], p4[0]), labels)
 
     plt.show()
 
 
 if __name__ == '__main__':
-    word_frequency(30)
-    # adjective_frequency(30)
+    word_frequency(N)

--- a/data_exploration/word_frequency.py
+++ b/data_exploration/word_frequency.py
@@ -1,0 +1,170 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from pyspark.sql import Row
+import collections
+
+import nltk
+from nltk import pos_tag
+
+import sys
+sys.path.append('../')
+from spark.init_spark import init_spark
+from config import AITA_CLEANED_COLLECTION
+
+nltk.download('averaged_perceptron_tagger')
+
+adjective_tags = ['JJ', 'JJR', 'JJS']
+words_to_ignore = ['i', 'u', 'aita', 'like', 'would', 'this', 'it', 'get', 'got', 'the']
+
+
+labels = ['NO A-HOLES HERE', 'ASSHOLE', 'NOT THE A-HOLE', 'EVERYONE SUCKS']
+
+
+def fill_0_values(max_label_len, list):
+    list_len = len(list)
+    if list_len < max_label_len:
+        list.extend([0] * (max_label_len - list_len))
+
+    return list
+
+
+def word_frequency(n):
+    spark = init_spark(AITA_CLEANED_COLLECTION)
+    data_rdd = spark.read.format('mongo').load().rdd
+
+    def filter(row):
+        words = []
+        list = [word.lower() for sublist in row['header'] for word in sublist] + \
+               [word.lower() for sublist in row['content'] for word in sublist]
+
+        for word in list:
+            if word not in words_to_ignore:
+                words.append(word)
+
+        return words
+
+    flattened_rdd = data_rdd \
+        .flatMap(lambda row: [Row(label=row['label'], word=word) for word in filter(row)])
+
+    result_rdd = flattened_rdd \
+        .map(lambda row: ((row['label'], row['word']), 1)) \
+        .reduceByKey(lambda x, y: x+y) \
+        .sortBy(lambda x: -x[1])
+
+    result = result_rdd.take(n)
+    print(result)
+    labels = spark.sparkContext.parallelize(result).map(lambda x: x[0][1]).distinct().collect()
+
+    r_data = labels
+    x = range(len(r_data))
+
+    d = collections.defaultdict(list)
+
+    for val in result:
+        print(val)
+        label = val[0][0]
+        d[label].append(val[1])
+
+    print(d[labels[0]])
+    print(d[labels[1]])
+    print(d[labels[2]])
+    print(d[labels[3]])
+
+    max_label_len = len(d[[k for k in d.keys() if len(d.get(k)) == max([len(n) for n in d.values()])][0]])
+
+    nah = fill_0_values(max_label_len, d[labels[0]])
+    ah = fill_0_values(max_label_len, d[labels[1]])
+    ntah = fill_0_values(max_label_len, d[labels[2]])
+    es = fill_0_values(max_label_len, d[labels[3]])
+    print(nah)
+    print(ah)
+    print(ntah)
+    print(es)
+
+    bottom_ntah = np.add(nah, ah).tolist()
+    bottom_es = np.add(bottom_ntah, ntah).tolist()
+
+    plt.figure(figsize=(20, 5))
+
+    p1 = plt.bar(x, nah, color='grey')
+    p2 = plt.bar(x, ah, bottom=nah, color='red')
+    p3 = plt.bar(x, ntah, bottom=bottom_ntah, color='green')
+    p4 = plt.bar(x, es, bottom=bottom_es, color='black')
+
+    plt.title('Distribution of the top {} {} for posts in r/AITA'.format(n, 'words'))
+    plt.xticks(x, r_data)
+    plt.xlabel('Words')
+    plt.ylabel('Count')
+
+    plt.legend((p1[0], p2[0], p3[0], p4[0]), labels)
+
+    plt.show()
+
+
+def adjective_frequency(n):
+    spark = init_spark(AITA_CLEANED_COLLECTION)
+    data_rdd = spark.read.format('mongo').load().rdd
+
+    def filter(row):
+        words = []
+        list = pos_tag([word.lower() for sublist in row['header'] for word in sublist] + \
+                         [word.lower() for sublist in row['content'] for word in sublist])
+        for word in list:
+            if word[1] in adjective_tags and word[0] not in words_to_ignore:
+                words.append(word[0])
+
+        return words
+
+    flattened_rdd = data_rdd.flatMap(lambda row: [Row(label=row['label'], word=word) for word in filter(row)])
+
+    result_rdd = flattened_rdd\
+        .map(lambda row: ((row['label'], row['word']), 1)) \
+        .reduceByKey(lambda x, y: x+y) \
+        .sortBy(lambda x: -x[1])
+
+    result = result_rdd.take(n)
+    labels = spark.sparkContext.parallelize(result).map(lambda x: x[0][1]).distinct().collect()
+
+    plot_count_by_label('adjectives', result, labels, n)
+
+
+def plot_count_by_label(pos, data, labels, n):
+    r_data = labels
+    x = range(len(r_data))
+
+    d = collections.defaultdict(list)
+
+    for val in data:
+        label = val[0][0]
+        d[label].append(val[1])
+
+    max_label_len = len(d[[k for k in d.keys() if len(d.get(k)) == max([len(n) for n in d.values()])][0]])
+
+    nah = fill_0_values(max_label_len, d[labels[0]])
+    ah = fill_0_values(max_label_len, d[labels[1]])
+    ntah = fill_0_values(max_label_len, d[labels[2]])
+    es = fill_0_values(max_label_len, d[labels[3]])
+
+    bottom_ntah = np.add(nah, ah).tolist()
+    bottom_es = np.add(bottom_ntah, ntah).tolist()
+
+    plt.figure(figsize=(20, 5))
+
+    p1 = plt.bar(x, nah, color='grey')
+    p2 = plt.bar(x, ah, bottom=nah, color='red')
+    p3 = plt.bar(x, ntah, bottom=bottom_ntah, color='green')
+    p4 = plt.bar(x, es, bottom=bottom_es, color='black')
+
+    plt.title('Distribution of the top {} {} for posts in r/AITA'.format(n, pos))
+    plt.xticks(x, r_data)
+    plt.xlabel('Words')
+    plt.ylabel('Count')
+
+    plt.legend((p1[0], p2[0], p3[0], p4[0]), labels)
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    word_frequency(30)
+    # adjective_frequency(30)

--- a/data_exploration/word_topics.py
+++ b/data_exploration/word_topics.py
@@ -1,0 +1,61 @@
+from pyspark.sql import Row
+from pyspark.ml.feature import CountVectorizer
+from pyspark.mllib.clustering import LDA
+from pyspark.mllib.linalg import Vectors
+
+import nltk
+
+
+import sys
+sys.path.append('../')
+from spark.init_spark import init_spark
+from config import AITA_CLEANED_COLLECTION
+
+nltk.download('averaged_perceptron_tagger')
+
+NUM_TOPICS = 15
+NUM_WORDS_PER_TOPICS = 10
+
+
+def word_topics(num_topics, num_words_per_topics):
+    spark = init_spark(AITA_CLEANED_COLLECTION)
+    data_rdd = spark.read.format('mongo').load().rdd
+
+    preprocessed_rdd = data_rdd\
+        .flatMap(lambda row: [[word.lower() for sublist in row['header'] for word in sublist] +
+                                      [word.lower() for sublist in row['content'] for word in sublist]]) \
+        .zipWithIndex() \
+        .map(lambda x: Row(index=x[1], words=x[0]))
+
+    preprocessed_df = spark.createDataFrame(preprocessed_rdd)
+
+    cv = CountVectorizer(inputCol='words', outputCol='vectors')
+    model = cv.fit(preprocessed_df)
+    vector_df = model.transform(preprocessed_df)
+
+    corpus = vector_df.select('index', 'vectors').rdd.map(lambda x: [x[0], Vectors.fromML(x[1])]).cache()
+
+    lda_model = LDA.train(corpus, k=num_topics, maxIterations=100, optimizer='online')
+    vocab_array = model.vocabulary
+
+    topic_indices = spark.sparkContext.parallelize(lda_model.describeTopics(maxTermsPerTopic=num_words_per_topics))
+
+    def vector_id_to_word(topic):
+        terms = topic[0]
+        weights = topic[1]
+        result = []
+        for i in range(num_words_per_topics):
+            result.append((vocab_array[terms[i]], weights[i]))
+        return result
+
+    topics = topic_indices.map(lambda topic: vector_id_to_word(topic)).collect()
+
+    for i in range(len(topics)):
+        print('Topic {}:'.format(i))
+        for item in topics[i]:
+            print(item)
+        print('\n')
+
+
+if __name__ == '__main__':
+    word_topics(NUM_TOPICS, NUM_WORDS_PER_TOPICS)

--- a/data_exploration/word_topics.py
+++ b/data_exploration/word_topics.py
@@ -5,7 +5,6 @@ from pyspark.mllib.linalg import Vectors
 
 import nltk
 
-
 import sys
 sys.path.append('../')
 from spark.init_spark import init_spark

--- a/data_exploration/word_topics.py
+++ b/data_exploration/word_topics.py
@@ -21,8 +21,7 @@ def word_topics(num_topics, num_words_per_topics):
     data_rdd = spark.read.format('mongo').load().rdd
 
     preprocessed_rdd = data_rdd\
-        .flatMap(lambda row: [[word.lower() for sublist in row['header'] for word in sublist] +
-                                      [word.lower() for sublist in row['content'] for word in sublist]]) \
+        .flatMap(lambda row: [row['header'].lower().split(' ') + row['content'].lower().split(' ')]) \
         .zipWithIndex() \
         .map(lambda x: Row(index=x[1], words=x[0]))
 

--- a/data_exploration/word_topics.py
+++ b/data_exploration/word_topics.py
@@ -3,20 +3,26 @@ from pyspark.ml.feature import CountVectorizer
 from pyspark.mllib.clustering import LDA
 from pyspark.mllib.linalg import Vectors
 
-import nltk
 
 import sys
 sys.path.append('../')
 from spark.init_spark import init_spark
 from config import AITA_CLEANED_COLLECTION
 
-nltk.download('averaged_perceptron_tagger')
-
 NUM_TOPICS = 15
 NUM_WORDS_PER_TOPICS = 10
 
 
 def word_topics(num_topics, num_words_per_topics):
+    """Generates topics from word clusters.
+
+    Arguments:
+        num_topics {integer} -- Number of topics to infer
+        num_words_per_topics {integer} -- Number of terms to collect for each topic
+
+    Returns:
+        None
+    """
     spark = init_spark(AITA_CLEANED_COLLECTION)
     data_rdd = spark.read.format('mongo').load().rdd
 

--- a/extractor.py
+++ b/extractor.py
@@ -1,6 +1,5 @@
 import argparse
 import datetime
-import sys
 
 import requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ six==1.14.0
 typed-ast==1.4.1
 urllib3==1.25.8
 wrapt==1.11.2
+nltk==3.4.5

--- a/spark/init_spark.py
+++ b/spark/init_spark.py
@@ -1,17 +1,16 @@
-import pyspark
 from pyspark.sql import SparkSession
+from config import MONGO_CONNECTION_STRING, AITA_DB_NAME
 
-AITA_DB_NAME = 'aitaDB'
-AITA_POSTS_COLLECTION = 'extractedinfo'
-MONGODB_URI = 'mongodb://127.0.0.1/{}.{}'.format(AITA_DB_NAME, AITA_POSTS_COLLECTION)
 
-def init_spark():
+def init_spark(collection_name):
+    mongodb_uri = '{}/{}.{}'.format(MONGO_CONNECTION_STRING, AITA_DB_NAME, collection_name)
+
     return SparkSession \
         .builder \
         .appName('AITA') \
         .master('local') \
-        .config('spark.driver.host','127.0.0.1') \
+        .config('spark.driver.host', '127.0.0.1') \
         .config('spark.jars.packages', 'org.mongodb.spark:mongo-spark-connector_2.11:2.4.1') \
-        .config('spark.mongodb.input.uri', MONGODB_URI) \
-        .config('spark.mongodb.output.uri', MONGODB_URI) \
+        .config('spark.mongodb.input.uri', mongodb_uri) \
+        .config('spark.mongodb.output.uri', mongodb_uri) \
         .getOrCreate()


### PR DESCRIPTION
**~~Example results for #11~~**
![image](https://user-images.githubusercontent.com/23409994/77301756-9a85b600-6cc6-11ea-81c1-5c880bf8bbc4.png)
**Updated results for #11** (about 2 mins runtime)
![image](https://user-images.githubusercontent.com/23409994/77390159-7def8980-6d6b-11ea-82e8-27431939fdea.png)


**Example results for #13** (about 2 mins runtime)
This uses the LDA algorithm to generate clusters of words that might belong to a topic t. More information about how it works can be found here: https://blog.echen.me/2011/08/22/introduction-to-latent-dirichlet-allocation/
```
Topic 0:
('i', 0.013185670250549236)
('hannah', 0.007911806423488819)
('waffle', 0.006910221184224243)
('flush', 0.004213581355548046)
('daniel', 0.004057439604350097)
('toilet', 0.003909753615209962)
('syrup', 0.0036800716230597705)
('oven', 0.0036652769467169217)
('howey', 0.003431165556864391)
('chili', 0.0030583404915135227)


Topic 1:
('i', 0.020943314247251533)
('lane', 0.015079414729325087)
('alex', 0.008065702534735266)
('ava', 0.0074640045394286465)
('speed', 0.005497109217821912)
('susan', 0.005105230951607352)
('bee', 0.00493051949737085)
('ryan', 0.0046280239318585385)
('david', 0.0034317947100103575)
('melanie', 0.0027877714291169578)


Topic 2:
('fluffy', 0.004511086763572053)
('lg', 0.0008696496535992866)
('i', 0.0006675766191423583)
('intentioned', 0.00022956513604756128)
('dog', 0.00022382818186363225)
('poodle', 0.00019016050812450356)
('fluff', 0.0001844619733827341)
('teddy', 0.0001831648981065157)
('want', 0.0001732341673513823)
('aaaalllwaaaays', 0.00016585925369759597)


Topic 3:
('i', 0.09202686000012215)
('like', 0.0075054817610374054)
('aita', 0.007403329235632279)
('friend', 0.006984671939750192)
('time', 0.006876440466282547)
('would', 0.0068183595111858996)
('get', 0.006789707053304594)
('she', 0.006654288872472845)
('said', 0.006401717424220447)
('told', 0.006310186736109044)


Topic 4:
('stamp', 0.013539232639111833)
('i', 0.00794018202555593)
('jon', 0.00488951651511409)
('jeep', 0.0038008157514540964)
('passport', 0.0035229943643133523)
('recipe', 0.0028079887928526364)
('measurement', 0.0026518529606370297)
('sims', 0.0024297236891754)
('abbie', 0.0020461349679283224)
('monopoly', 0.0019637439671507505)


Topic 5:
('howrse', 0.0031898915441897647)
('farm', 0.002177217667362925)
('i', 0.0021173751873708566)
('villager', 0.0014270745746615306)
('opponent', 0.0013572248725507046)
('referee', 0.0010905298818984274)
('haunt', 0.0007279189980946149)
('breed', 0.000721227242275059)
('fouled', 0.0006572517060530785)
('howrses', 0.0006535999135164764)


Topic 6:
('ben', 0.0226206760395099)
('chloe', 0.010989055062459516)
('turtle', 0.007887167106932097)
('i', 0.005822362053194937)
('jay', 0.005390889092297558)
('samantha', 0.004644053433594096)
('jennifer', 0.0030943220446968873)
('percy', 0.0027483652864642772)
('hiking', 0.002224977249916688)
('alex', 0.0021507016444916836)


Topic 7:
('diabetic', 0.0012469035475663102)
('pta', 0.00042304591739429154)
('concession', 0.00037700702466567)
('scourge', 0.0003341625431732907)
('coke', 0.0002618786108857359)
('ableism', 0.0002462148597665525)
('t2', 0.0002446593582927998)
('i', 0.00021490373376964372)
('railroaded', 0.00020809124656136219)
('ableist', 0.00018323536530274255)


Topic 8:
('tilda', 0.0034141978246609527)
('connie', 0.0018063738626266804)
('i', 0.0014073945254511086)
('spaghetti', 0.0013375631413774633)
('flatiron', 0.0008833219408902084)
('suspecting', 0.0008651103631463358)
('pornhub', 0.0008404095789660913)
('allah', 0.0005612330989316981)
('fil', 0.0005215834733109277)
('aglio', 0.0005094162280690182)


Topic 9:
('night', 0.00012854845849755834)
('friend', 0.00012308725501764233)
('i', 0.00010886599420995043)
('aita', 0.00010592978009668618)
('would', 8.404131978187912e-05)
('one', 8.335604072437531e-05)
('u', 8.220651754057147e-05)
('the', 7.978758336231578e-05)
('since', 7.73596970235821e-05)
('place', 7.70887356790621e-05)


Topic 10:
('rose', 0.018898133577650487)
('julia', 0.009350796738504506)
('moon', 0.001663841090815257)
('i', 0.0013736105501618982)
('peggy', 0.0011170891971829177)
('acupuncture', 0.0009917321812292184)
('regularity', 0.0009243310461935932)
('dud', 0.0006443926630952048)
('qi', 0.0006291719581887059)
('yang', 0.0006281449499466739)


Topic 11:
('stanley', 0.0018374831088549981)
('blues', 0.0010137501355736542)
('zima', 0.0009867644115877632)
('ofrenda', 0.0004823113607876665)
('authentic', 0.00046755869311360934)
('muertos', 0.0004637652335100642)
('i', 0.0004572647065078958)
('de', 0.000378019671596051)
('stl', 0.0003699628361029734)
('ch', 0.00035278273073346397)


Topic 12:
('firefly', 0.003720287366295889)
('chess', 0.002866597819620388)
('insect', 0.00166427472281758)
('fide', 0.0013120336393362415)
('zapper', 0.0012734329422024952)
('i', 0.000897336416598169)
('housefly', 0.0008444709565173189)
('gnat', 0.000841871915620774)
('glow', 0.0008171530185119139)
('carcass', 0.0007838074324765024)


Topic 13:
('i', 0.0107859926526266)
('piano', 0.008861911844803278)
('lauren', 0.008220690614994449)
('ally', 0.0063806728512382565)
('caty', 0.0038376706083999143)
('engine', 0.0027776223678054263)
('pakistan', 0.002768678190131976)
('earbud', 0.002765494800385607)
('violin', 0.0026480873939775332)
('bonnie', 0.00238421182441511)


Topic 14:
('i', 0.058737517748202545)
('wedding', 0.013851375462612508)
('name', 0.012834816141956749)
('my', 0.011579272101059657)
('family', 0.010909367820150517)
('husband', 0.00810355276764783)
('would', 0.00773857722996206)
('want', 0.007291003499384249)
('child', 0.0068284651474224065)
('like', 0.0068162963353990405)
```

